### PR TITLE
ui: move list title to floating window border

### DIFF
--- a/lua/miniharp/ui.lua
+++ b/lua/miniharp/ui.lua
@@ -381,7 +381,7 @@ local function toggle_swap_mark()
 end
 
 local function position_window(lines)
-    local width = 0
+    local width = vim.fn.strdisplaywidth(window_title)
     for _, line in ipairs(lines) do
         width = math.max(width, vim.fn.strdisplaywidth(line))
     end

--- a/lua/miniharp/ui.lua
+++ b/lua/miniharp/ui.lua
@@ -8,6 +8,7 @@ local utils = require('miniharp.utils')
 local ns = vim.api.nvim_create_namespace('MiniharpUI')
 local win, buf
 local last_opts = {}
+local window_title = 'MiniHarp'
 local config = {
     position = 'center',
     show_hints = true,
@@ -64,12 +65,11 @@ end
 ---@return string[], table
 local function build_lines(opts)
     opts = opts or {}
-    local lines = { 'Miniharp marks' }
-    local row_offset = #lines
+    local lines = {}
     local current_file = ''
     local current_idx
     local meta = {
-        row_offset = row_offset,
+        row_offset = 0,
         rows = {},
         current_idx = nil,
         close_line = nil,
@@ -94,8 +94,7 @@ local function build_lines(opts)
 
     if opts.msg and opts.msg ~= '' then
         lines[#lines + 1] = ' ' .. opts.msg
-        row_offset = #lines
-        meta.row_offset = row_offset
+        meta.row_offset = #lines
     end
 
     if #state.marks == 0 then
@@ -155,10 +154,16 @@ end
 
 local function apply_highlights(lines, meta)
     vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
-    vim.api.nvim_buf_add_highlight(buf, ns, 'Title', 0, 0, -1)
 
-    if meta.row_offset > 1 then
-        vim.api.nvim_buf_add_highlight(buf, ns, 'Comment', 1, 0, -1)
+    if meta.row_offset > 0 then
+        vim.api.nvim_buf_add_highlight(
+            buf,
+            ns,
+            'Comment',
+            meta.row_offset - 1,
+            0,
+            -1
+        )
     end
 
     if #state.marks == 0 then
@@ -525,6 +530,8 @@ function M.open(opts)
         height = height,
         style = 'minimal',
         border = 'rounded',
+        title = window_title,
+        title_pos = 'center',
         noautocmd = true,
     })
 


### PR DESCRIPTION
## Summary
- move the list title to the floating window border
- free the first line for actual list content
- keep existing behavior unchanged
## Why
The title currently uses the first list row. Moving it to the border keeps the UI cleaner.
## Before
<img width="558" height="141" alt="image" src="https://github.com/user-attachments/assets/21223811-cbf4-4ee4-b0e5-ae17631661b2" />

## After
<img width="570" height="124" alt="image" src="https://github.com/user-attachments/assets/1cdc8c30-4afd-4ace-938f-7320ad3aa249" />


