### PR TITLE
feat: control notifications via config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ require('miniharp').setup({
   autoload = true, -- load marks for this cwd on startup (default: true)
   autosave = true, -- save marks for this cwd on exit (default: true)
   show_on_autoload = false, -- show popup list after a successful autoload (default: false)
+  notifications = true, -- enable vim.notify messages (default: true)
   ui = {
     position = 'center', -- 'center' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
     show_hints = true, -- show close hints in the floating list (default: true)
@@ -65,6 +66,7 @@ require('miniharp').setup({
     autoload = true,
     autosave = true,
     show_on_autoload = false,
+    notifications = true,
     ui = {
       position = 'center', -- `top-left`, `top-right`, `bottom-left`, `bottom-right`.
       show_hints = true,
@@ -112,6 +114,7 @@ All functions are exposed from `require('miniharp')`:
   ---@field autoload? boolean          @Load saved marks for this cwd on startup (default: true)
   ---@field autosave? boolean          @Save marks for this cwd on exit (default: true)
   ---@field show_on_autoload? boolean  @Show the marks list UI after a successful autoload (default: false)
+  ---@field notifications? boolean      @Enable vim.notify messages (default: true)
   ---@field ui? MiniharpUIOpts         @Floating list UI options
 
   ---@class MiniharpUIOpts

--- a/lua/miniharp/core.lua
+++ b/lua/miniharp/core.lua
@@ -2,6 +2,7 @@ local state = require('miniharp.state')
 local ui = require('miniharp.ui')
 local utils = require('miniharp.utils')
 local marks = require('miniharp.marks')
+local notifier = require('miniharp.notify')
 
 ---@class MiniharpMarks
 local M = {}
@@ -26,7 +27,7 @@ end
 ---@param step integer
 local function cycle(step)
     if #state.marks == 0 then
-        return vim.notify('miniharp: no file marks yet', vim.log.levels.WARN)
+        return notifier.notify('miniharp: no file marks yet', vim.log.levels.WARN)
     end
 
     local cursor = state.idx
@@ -46,7 +47,7 @@ local function cycle(step)
 
         local ok, reason = marks.jump_to(i)
         if ok then
-            vim.api.nvim_echo(
+            notifier.echo(
                 { { ('miniharp %d/%d'):format(i, #state.marks), 'ModeMsg' } },
                 false,
                 {}
@@ -67,7 +68,7 @@ local function cycle(step)
     end
 
     if #state.marks == 0 then
-        vim.notify('miniharp: no file marks yet', vim.log.levels.WARN)
+        notifier.notify('miniharp: no file marks yet', vim.log.levels.WARN)
     end
 
     ui.refresh()
@@ -79,7 +80,7 @@ end
 function M.add_file()
     local file = utils.bufname()
     if file == '' then
-        vim.notify(
+        notifier.notify(
             'miniharp: cannot mark an unnamed buffer',
             vim.log.levels.WARN
         )
@@ -157,12 +158,12 @@ end
 ---@param i integer
 function M.go_to(i)
     if #state.marks == 0 then
-        vim.notify('miniharp: no file marks yet', vim.log.levels.WARN)
+        notifier.notify('miniharp: no file marks yet', vim.log.levels.WARN)
         return
     end
 
     if not is_positive_integer(i) then
-        vim.notify(
+        notifier.notify(
             'miniharp: mark position must be a positive integer',
             vim.log.levels.WARN
         )
@@ -185,7 +186,7 @@ function M.go_to(i)
         target = math.min(target, #state.marks)
     end
 
-    vim.notify('miniharp: no file marks yet', vim.log.levels.WARN)
+    notifier.notify('miniharp: no file marks yet', vim.log.levels.WARN)
     ui.refresh()
 end
 

--- a/lua/miniharp/init.lua
+++ b/lua/miniharp/init.lua
@@ -6,6 +6,7 @@ local utils = require('miniharp.utils')
 local core = require('miniharp.core')
 local storage = require('miniharp.storage')
 local ui = require('miniharp.ui')
+local notifier = require('miniharp.notify')
 
 local function is_missing_session(err)
     return err and string.find(err, 'no session file for cwd', 1, true)
@@ -61,7 +62,7 @@ local function ensure_dirchange(opts)
             if opts.autosave ~= false then
                 local ok, err = storage.save(old_cwd)
                 if not ok then
-                    vim.notify(
+                    notifier.notify(
                         ('miniharp: save failed for %s - %s'):format(
                             vim.fn.fnamemodify(old_cwd, ':~:.'),
                             err or 'unknown error'
@@ -76,7 +77,7 @@ local function ensure_dirchange(opts)
             if opts.autoload then
                 local ok, err = storage.load(new_cwd)
                 if not ok and not is_missing_session(err) then
-                    vim.notify(
+                    notifier.notify(
                         'miniharp: ' .. (err or 'unknown error'),
                         vim.log.levels.WARN
                     )
@@ -116,7 +117,7 @@ end
 function M.save()
     local ok, err = storage.save()
     if not ok then
-        vim.notify(
+        notifier.notify(
             'miniharp: ' .. (err or 'unknown error'),
             vim.log.levels.ERROR
         )
@@ -129,7 +130,7 @@ function M.restore()
     if not ok then
         local level = is_missing_session(err) and vim.log.levels.INFO
             or vim.log.levels.ERROR
-        vim.notify('miniharp: ' .. (err or 'unknown error'), level)
+        notifier.notify('miniharp: ' .. (err or 'unknown error'), level)
     end
 end
 
@@ -137,6 +138,7 @@ end
 ---@field autoload? boolean  @Load saved marks for this cwd on startup (default: true)
 ---@field autosave? boolean  @Save marks for this cwd on exit (default: true)
 ---@field show_on_autoload? boolean  @Show the marks list UI after a successful autoload (default: false)
+---@field notifications? boolean  @Enable vim.notify messages (default: true)
 ---@field ui? MiniharpUIOpts  @Floating list UI options
 
 ---@class MiniharpUIOpts
@@ -148,6 +150,7 @@ end
 ---@param opts? MiniharpOpts
 function M.setup(opts)
     opts = opts or {}
+    state.notifications = opts.notifications ~= false
     ui.configure(opts.ui)
 
     ensure_autosave_positions()
@@ -160,7 +163,7 @@ function M.setup(opts)
         local ok, err = storage.load()
         if not ok then
             if not is_missing_session(err) then
-                vim.notify(
+                notifier.notify(
                     'miniharp: ' .. (err or 'unknown error'),
                     vim.log.levels.WARN
                 )

--- a/lua/miniharp/marks.lua
+++ b/lua/miniharp/marks.lua
@@ -1,5 +1,6 @@
 local state = require('miniharp.state')
 local utils = require('miniharp.utils')
+local notifier = require('miniharp.notify')
 
 local uv = vim.uv or vim.loop
 
@@ -58,13 +59,13 @@ end
 function M.jump_to(i)
     local mark = state.marks[i]
     if not mark then
-        vim.notify('miniharp: no mark #' .. tostring(i), vim.log.levels.WARN)
+        notifier.notify('miniharp: no mark #' .. tostring(i), vim.log.levels.WARN)
         return false, 'missing-mark'
     end
 
     if not uv.fs_stat(mark.file) then
         M.remove_at(i)
-        vim.notify(
+        notifier.notify(
             ('miniharp: removed missing mark %s'):format(utils.pretty(mark.file)),
             vim.log.levels.WARN
         )

--- a/lua/miniharp/notify.lua
+++ b/lua/miniharp/notify.lua
@@ -1,0 +1,27 @@
+local state = require('miniharp.state')
+
+local M = {}
+
+---@param msg string
+---@param level? integer
+---@param opts? table
+function M.notify(msg, level, opts)
+    if state.notifications == false then
+        return
+    end
+
+    vim.notify(msg, level, opts)
+end
+
+---@param chunks any[]
+---@param history boolean
+---@param opts table<string,any>|nil
+function M.echo(chunks, history, opts)
+    if state.notifications == false then
+        return
+    end
+
+    vim.api.nvim_echo(chunks, history, opts)
+end
+
+return M

--- a/lua/miniharp/notify.lua
+++ b/lua/miniharp/notify.lua
@@ -10,7 +10,7 @@ function M.notify(msg, level, opts)
         return
     end
 
-    vim.notify(msg, level, opts)
+    return vim.notify(msg, level, opts)
 end
 
 ---@param chunks any[]
@@ -21,7 +21,7 @@ function M.echo(chunks, history, opts)
         return
     end
 
-    vim.api.nvim_echo(chunks, history, opts)
+    return vim.api.nvim_echo(chunks, history, opts)
 end
 
 return M

--- a/lua/miniharp/state.lua
+++ b/lua/miniharp/state.lua
@@ -9,6 +9,7 @@ local utils = require('miniharp.utils')
 ---@field marks MiniharpMark[]
 ---@field cwd string
 ---@field idx integer
+---@field notifications boolean
 ---@field augroup? integer
 ---@field ui_win? integer
 ---@field ui_origin_win? integer
@@ -20,6 +21,7 @@ M = {
     marks = {},
     cwd = utils.norm(vim.fn.getcwd()),
     idx = 0,
+    notifications = true,
     augroup = nil,
     ui_win = nil,
     ui_origin_win = nil,

--- a/lua/miniharp/ui.lua
+++ b/lua/miniharp/ui.lua
@@ -4,6 +4,7 @@ local M = {}
 local marks = require('miniharp.marks')
 local state = require('miniharp.state')
 local utils = require('miniharp.utils')
+local notifier = require('miniharp.notify')
 
 local ns = vim.api.nvim_create_namespace('MiniharpUI')
 local win, buf
@@ -42,7 +43,7 @@ local function normalize_position(position)
         return position
     end
 
-    vim.notify(
+    notifier.notify(
         ("miniharp: invalid ui.position '%s', using 'center'"):format(position),
         vim.log.levels.WARN
     )

--- a/nvim_test.lua
+++ b/nvim_test.lua
@@ -8,6 +8,7 @@ require('miniharp').setup({
     autoload = true,
     autosave = true,
     show_on_autoload = true,
+    notifications = false,
     ui = {
         position = 'top-right',
         show_hints = false,


### PR DESCRIPTION
Personally I find the notifications/echo annoying. So I added a config value to turn them off like this:

```lua
require('miniharp').setup({
     notifications = false,
   })
```
There's a new module `notify.lua` that is just a tiny wrapper around vim.notify which basically just doesn't fire when the config value is set to false.

Default value is true to preserve the behaviour that you had before.